### PR TITLE
sagas refractor

### DIFF
--- a/src/state/counter/sagas.js
+++ b/src/state/counter/sagas.js
@@ -1,5 +1,4 @@
-
-import { call, put, takeEvery, takeLatest } from 'redux-saga/effects';
+import { all, call, put, takeEvery, takeLatest } from 'redux-saga/effects';
 
 const get = (what) => fetch(`http://localhost:3000/${what}`)
     .then((res) => res.json())
@@ -13,6 +12,12 @@ function* load(action) {
     }
 }
 
-export default [
-    takeEvery("[COUNTER] LoadRequest", load)
-];
+function* watchLoad () {
+    yield takeEvery("[COUNTER] LoadRequest", load)
+}
+
+export default function* () {
+    yield all([
+        call(watchLoad)
+    ])
+}

--- a/src/state/index.js
+++ b/src/state/index.js
@@ -4,7 +4,7 @@ import {
   createStore
 } from 'redux';
 import createSagaMiddleware from 'redux-saga';
-import { all } from 'redux-saga/effects';
+import { all, call } from 'redux-saga/effects';
 
 import { counterActions, counterReducers, counterSagas } from './counter';
 import { todoListActions, todoListReducers } from './todo-list';
@@ -27,7 +27,7 @@ export function configureStore(initialState = {}) {
 
   function* rootSaga() {
     yield all([
-      ...counterSagas
+      call(counterSagas)
     ])
   }
   sagaMiddleware.run(rootSaga);


### PR DESCRIPTION
The advantage of this solutions is that the generator function that gets exported by default from your sagas.js will be responsible to take all 'watch' functions like this

```
export default function* () {
    yield all([
        call(watchLoad),
        call(watchLoad2),
        call(watchLoad3)
    ])
}
``` 
This avoids the need to export every single watch function